### PR TITLE
Add bison and flex and real package lib names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ These scripts download (`git clone`) and install:
 
 ## Requirements
 
-1. Install gcc/clang, make, patch, git, texinfo wget, zlib and ucl if you don't have those.
+1. Install gcc/clang, make, patch, git, texinfo, wget, bison, zlib (zlib1g-dev is the ubuntu package zlib name), flex, and ucl (libucl-dev, libucl1) if you don't have those.
 
 2. Add this to your login script (example: `~/.bash_profile`) 
 **Note:** Ensure that you have full access to the PS2DEV path. You can change the PS2DEV path with the following requirements: use only absolute paths, don't use spaces, use only Latin characters.


### PR DESCRIPTION
Add bison and flex (as dependencies from Ubuntu Docker CI says), and the *real package names* of UCL and Zlib, for users to find it with apt search/install