### PR TITLE
Use again default Xcode 12 for compilation

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -30,11 +30,6 @@ jobs:
         brew update
         brew install texinfo bison flex gnu-sed gsl gmp mpfr
 
-    - name: Switch to Xcode 11.7
-      if: matrix.os == 'macOS-latest'
-      run: |
-        sudo xcode-select --switch /Applications/Xcode_11.7.app
-
     - name: Runs all the stages in the shell
       run: |
         export PS2DEV=$PWD/ps2dev


### PR DESCRIPTION
## Description

Now we can compile again using Xcode 12 after these 2 PRs

https://github.com/ps2dev/ps2toolchain-dvp/pull/4
https://github.com/ps2dev/ps2toolchain-iop/pull/4