### PR TITLE
Add pre-release section

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -60,7 +60,18 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       id: tag
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-    
+
+    - name: Create pre-release
+      if: github.ref == 'refs/heads/master'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ps2dev-${{matrix.os}}.tar.gz
+        prerelease: true
+        name: "Development build"
+        tag_name: "latest"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Release
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Now tested and works fine. `softprops/action-gh-release` action is better than the default one, cause it can handle matrix (it appends artifacts, not replaced them).
Example output:
https://github.com/AKuHAK/ps2dev/releases/tag/latest