### PR TITLE
Include libcvd as standard library

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -33,7 +33,7 @@ jobs:
       if: matrix.os[0] == 'macOS-latest'
       run: |
         brew update
-        brew install texinfo bison flex gnu-sed gsl gmp mpfr
+        brew install texinfo bison flex gnu-sed gsl gmp mpfr libmpc
         echo "MSYSTEM=x64" >> $GITHUB_ENV
 
     - name: Install MSYS2 texinfo bison flex

--- a/scripts/002-ps2sdk.sh
+++ b/scripts/002-ps2sdk.sh
@@ -32,6 +32,8 @@ cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${REPO_REFERENCE}
 # Workaround 2018/10/18: remove -j as the ps2toolchain's Makefiles do not have dependencies set up properly.
 make --quiet clean && make --quiet && make --quiet install && make --quiet clean || { exit 1; }
 
-## gcc needs to include both libps2sdkc and libkernel from ps2sdk to be able to build executables.
+## gcc needs to include libps2sdkc, libkernel and libcdvd from ps2sdk to be able to build executables,
+## because they are part of the standard libraries 
 ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libps2sdkc.a" || { exit 1; }
 ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a" || { exit 1; }
+ln -sf "$PS2SDK/ee/lib/libcdvd.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcdvd.a"  || { exit 1; }


### PR DESCRIPTION
This PR just create a simbolink link in the `$PS2DEV/ee/mips64r5900el-ps2-elf/lib/` for the `libcdvd` because it now takes part of the standard libraries