### PR TITLE
Rename libps2sdkc to libcglue

### DIFF
--- a/scripts/002-ps2sdk.sh
+++ b/scripts/002-ps2sdk.sh
@@ -32,8 +32,8 @@ cd "$REPO_FOLDER" && git fetch origin && git reset --hard "origin/${REPO_REFEREN
 # Workaround 2018/10/18: remove -j as the ps2toolchain's Makefiles do not have dependencies set up properly.
 make --quiet clean && make --quiet && make --quiet install && make --quiet clean || { exit 1; }
 
-## gcc needs to include libps2sdkc, libkernel and libcdvd from ps2sdk to be able to build executables,
+## gcc needs to include libcglue, libkernel and libcdvd from ps2sdk to be able to build executables,
 ## because they are part of the standard libraries
-ln -sf "$PS2SDK/ee/lib/libps2sdkc.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libps2sdkc.a" || { exit 1; }
+ln -sf "$PS2SDK/ee/lib/libcglue.a" "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcglue.a" || { exit 1; }
 ln -sf "$PS2SDK/ee/lib/libkernel.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libkernel.a" || { exit 1; }
 ln -sf "$PS2SDK/ee/lib/libcdvd.a"  "$PS2DEV/ee/mips64r5900el-ps2-elf/lib/libcdvd.a"  || { exit 1; }


### PR DESCRIPTION
## Description 
This PR is part of a collection, where we have renamed the `libps2sdkc` to a more appropriate name `libcglue`

All the related PRs are:
- [gcc](https://github.com/ps2dev/gcc/pull/1)
- [newlib](https://github.com/ps2dev/newlib/pull/4)
- [ps2sdk](https://github.com/ps2dev/ps2sdk/pull/279)
- [ps2dev](https://github.com/ps2dev/ps2dev/pull/52)

The CI/CD is currently failing because it requires a proper merging process.

The merging process should be:
1. Merge `gcc`
2. Merge `newlib`
3. Trigger a new CI/CD in `ps2toolchain`
4. Merge `ps2sdk`
5. Merge `ps2dev`