### PR TITLE
add workflow payload

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,15 +60,16 @@ jobs:
         export DISPATCH_ACTION="$(echo run_build)"
         echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
 
-    - name: "create payload with parent payload"
-      if: ${{ github.event_name }} == 'repository_dispatch'
+    - name: "create payload with this repository payload"
+      if: ${{ github.event_name }} != 'repository_dispatch'
       run: |
         export REPO_PAYLOAD="$(echo {\"ref\": \"${{ github.ref }}\", \"parent\": \"${{ github.repository }}\", \"parent_sha\": \"${{ steps.slug.outputs.sha8 }}\"})"
         echo "NEW_REPO_PAYLOAD=$REPO_PAYLOAD" >> $GITHUB_ENV
-    - name: "create payload with current repository payload"
-      if: ${{ github.event_name }} != 'repository_dispatch'
+
+    - name: "create payload with parent repository payload"
+      if: ${{ github.event_name }} == 'repository_dispatch'
       run: |
-        export REPO_PAYLOAD="$(echo {\"ref\": \"${{ github.ref }}\"})"
+        export REPO_PAYLOAD="$(echo {\"ref\": \"${{ github.ref }}\", \"parent:\" \"${{ github.event.client_payload.parent }}\", \"parent_sha\": \"${{ github.event.client_payload.parent_sha }}\"})"
         echo "NEW_REPO_PAYLOAD=$REPO_PAYLOAD" >> $GITHUB_ENV
 
     - name: Repository Dispatch to ps2homebrew ps2dev_forwarder to do broadcast over there

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,17 @@ jobs:
         export DISPATCH_ACTION="$(echo run_build)"
         echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
 
+    - name: "create payload with parent payload"
+      if: ${{ github.event_name }} == 'repository_dispatch'
+      run: |
+        export REPO_PAYLOAD="$(echo {\"ref\": \"${{ github.ref }}\", \"parent\": \"${{ github.repository }}\", \"parent_sha\": \"${{ steps.slug.outputs.sha8 }}\"})"
+        echo "NEW_REPO_PAYLOAD=$REPO_PAYLOAD" >> $GITHUB_ENV
+    - name: "create payload with current repository payload"
+      if: ${{ github.event_name }} != 'repository_dispatch'
+      run: |
+        export REPO_PAYLOAD="$(echo {\"ref\": \"${{ github.ref }}\"})"
+        echo "NEW_REPO_PAYLOAD=$REPO_PAYLOAD" >> $GITHUB_ENV
+
     - name: Repository Dispatch to ps2homebrew ps2dev_forwarder to do broadcast over there
       uses: peter-evans/repository-dispatch@v1
       if: env.DISPATCH_TOKEN != null
@@ -67,4 +78,4 @@ jobs:
         repository: ps2homebrew/ps2dev_forwarder
         token: ${{ secrets.DISPATCH_TOKEN }}
         event-type: ${{ env.NEW_DISPATCH_ACTION }}
-        client-payload: '{"ref": "${{ github.ref }}", "parent": "${{ github.repository }}", "parent_sha": "${{ steps.slug.outputs.sha8 }}"}'
+        client-payload: '${{ env.NEW_REPO_PAYLOAD }}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Get short SHA
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+
     - name: Extract DOCKER_TAG using tag name
       if: startsWith(github.ref, 'refs/tags/')
       run: |
@@ -63,4 +67,4 @@ jobs:
         repository: ps2homebrew/ps2dev_forwarder
         token: ${{ secrets.DISPATCH_TOKEN }}
         event-type: ${{ env.NEW_DISPATCH_ACTION }}
-        client-payload: '{"ref": "${{ github.ref }}"}'
+        client-payload: '{"ref": "${{ github.ref }}", "parent": "${{ github.repository }}", "parent_sha": "${{ steps.slug.outputs.sha8 }}"}'


### PR DESCRIPTION
# description

this pull request is the first one in a series of pull requests to all the ps2dev repositories that make use of the
```yaml
  repository_dispatch:
    types: [run_build]
```
Event type to trigger workflow execution on child repositories...

## Whats the purpose?

That every repository triggered by this event can know Wich repository caused the trigger, and more specifically, wich commit was responsible...

## Whats the main goal?
store different variations of the same OPL Commit on OPL MEGA Archive as different artifact, currently, the SDK updates overwrite OPL Artifacts...

Having variations of the same commit always available will be very usefull to track regressions on the SDK trough the OPL Commits...



