### PR TITLE
Fix windows compilation

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -42,10 +42,11 @@ jobs:
       with:
         msystem: MINGW32
         install: |
-          base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mpc-devel tar
-          mingw-w64-i686-cmake mingw-w64-i686-extra-cmake-modules mingw-w64-i686-make
-        update: true
+          base-devel git make texinfo flex bison patch binutils mpc-devel tar
+        update: false
         shell: msys2 {0}
+        pacboy: >-
+          make:i gcc:i extra-cmake-modules:i
 
     - name: Runs all the stages in the shell
       continue-on-error: true


### PR DESCRIPTION
Modified github action script to downgrade gcc version.
it seems that it is [known issue](https://sourceforge.net/p/mingw-w64/bugs/974/).
As MSYS2 does not allow to handle versions, we cannot control how exactly it downgrades, so in future if builds start to fail again it will be necessary to move switch `update` back to `true`.

Fixes #64 