### PR TITLE
fix dependencies for fedora/centos on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sudo apt -y install gcc g++ make cmake patch git texinfo flex bison gettext libg
 -   Fedora/CentOS
 
 ```bash
-sudo dnf -y install gcc make cmake patch git texinfo flex bison gettext gmp-devel mpfr-devel libmpc zlib-devel
+sudo dnf -y install gcc make cmake patch git texinfo flex bison gettext gmp-devel mpfr-devel libmpc-devel zlib-devel
 ```
 
 -   Alpine


### PR DESCRIPTION
replace `libmpc` with `libmpc-devel`. building gcc fails without the `libmpc-devel` dependency.

before fix:
```
configure: error: Building GCC requires GMP 4.2+, MPFR 2.3.1+ and MPC 0.8.0+.
Try the --with-gmp, --with-mpfr and/or --with-mpc options to specify
their locations.  Source code for these libraries can be found at
their respective hosting sites as well as at
ftp://gcc.gnu.org/pub/gcc/infrastructure/.  See also
http://gcc.gnu.org/install/prerequisites.html for additional info.  If
you obtained GMP, MPFR and/or MPC from a vendor distribution package,
make sure that you have installed both the libraries and the header
files.  They may be located in separate packages.
```

after fix:
compilation continued as usual