### PR TITLE
ci: Fix silent build failures on Ubuntu

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -81,7 +81,11 @@ jobs:
       if: startsWith(matrix.os.runs-on, 'ubuntu')
       run: |
         apt-get -y update
-        apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install texinfo bison flex gettext autopoint autoconf automake libgmp3-dev libmpfr-dev libmpc-dev cmake g++ gcc git libgsl-dev make patch zlib1g-dev wget curl
+        apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' install texinfo bison flex gettext autopoint autoconf automake libtool libgmp3-dev libmpfr-dev libmpc-dev g++ gcc git libgsl-dev make patch zlib1g-dev wget curl ca-certificates gpg
+        # Install newer cmake (3.20+) from Kitware's official repository
+        # Ubuntu 20.04's default cmake is 3.16.3, but xz v5.8.1 requires 3.20+
+        curl -LsSf https://apt.kitware.com/kitware-archive.sh | sh
+        apt-get -y install cmake
 
     - name: Install macOS packages (brew)
       if: startsWith(matrix.os.runs-on, 'macos') && matrix.os.macos-package-manager == 'brew'
@@ -110,6 +114,7 @@ jobs:
 
     - name: Runs all the stages in the shell
       run: |
+        set -e
         . ./config/ci-env.sh
         if test -f ./build-all.sh; then ./build-all.sh; fi
         if test -f ./toolchain.sh; then ./toolchain.sh; fi


### PR DESCRIPTION
Three issues causing build errors to go unnoticed:

1. Shell error handling: `bash {0}` loses -e flag, and the last command `if test -f ./toolchain.sh` always returns 0 even when build-all.sh fails. Added `set -e` to catch errors properly.

2. CMake version: Ubuntu 20.04's cmake is 3.16.3, but xz v5.8.1 requires 3.20+. Now installs cmake from Kitware's official apt repository to get a modern version.

3. Missing libtool: libconfuse requires libtool for autoreconf. Added libtool to Ubuntu package list.

These issues caused ps2sdk-ports builds to fail silently, resulting in missing gsKit and other libraries in Ubuntu artifacts.

Fixes #116 