### PR TITLE
Make container useful for CI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,5 @@ ENV GSKIT $PS2DEV/gsKit
 ENV PATH $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/bin:${PS2SDK}/bin
 
 COPY --from=0 ${PS2DEV} ${PS2DEV}
+
+RUN apk add --no-cache gmp mpc1 mpfr4 make pkgconf cmake git


### PR DESCRIPTION
This adds everything that the container needs to be able to build code. Without gmp, mpc1 and mpfr4, gcc will not run. With git installed, people can do recursive clones in GitHub Actions. And make, cmake and pkgconf are required to build most applications.