### PR TITLE
Make gcc able to run in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,4 @@ ENV GSKIT $PS2DEV/gsKit
 ENV PATH $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/bin:${PS2SDK}/bin
 
 COPY --from=0 ${PS2DEV} ${PS2DEV}
+RUN apk add --no-cache gmp mpc1 mpfr4


### PR DESCRIPTION
Right now these dependencies for mips64r5900el-ps2-elf-gcc are not included, so it cannot be used. This PR fixes that.