### PR TITLE
READme.md: add missing build dependency to Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ apk add build-base cmake git texinfo flex bison gettext gmp-dev mpfr-dev mpc1-de
 * Void
 
 ```bash
-sudo xbps-install -Su mpfr libmpc-devel base-devel bison gettext texinfo gmp-devel gsl-devel zlib-devel cmake patch git boost-devel boost
+sudo xbps-install -Su mpfr libmpc-devel base-devel bison gettext gettext-devel-tools texinfo gmp-devel gsl-devel zlib-devel cmake patch git boost-devel boost
 ```
 
 * Arch


### PR DESCRIPTION
Building the toolchain (specifically ps2sdk-ports) fails without 'gettext-devel-tools' installed, as this package contains autopoint, which is invoked by the build.