### PR TITLE
README.md: fix for it not being able to find the .pc files for `mips64r5900el-ps2-elf-pkg-config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ cd ps2dev
 ./build-all.sh
 ```
 
+7. "Optional.* To use `mips64r5900el-ps2-elf-pkg-config` in your Makefile/CMakeLists.txt if you downloaded `PS2DEV` from GitHub Actions.
+
+```bash
+sed -i'' "s|/__w/ps2dev/ps2dev/ps2dev/ps2sdk/ports|${PS2SDK}/ports|g"   "$PS2SDK"/ports/lib/pkgconfig/*.pc
+sed -i'' "s|/__w/ps2dev/ps2dev/ps2dev/ps2sdk/ports|${PS2SDK}/ports|g"   "$GSKIT"/lib/pkgconfig/*.pc
+sed -i'' "s|/__w/ps2dev/ps2dev/ps2dev/gsKit|${GSKIT}/|g"   "$GSKIT"/lib/pkgconfig/*.pc
+```
+
 ## Container image generation
 
 This repo also uses CI/CD to create a container image, compatible with Docker and Podman, called `ps2dev/ps2dev:latest` per change. This is useful if you're a developer that wants to create/port an application to the PS2. You can compile your project using this container image.


### PR DESCRIPTION
Fixes `mips64r5900el-ps2-elf-pkg-config` finding the .pc files so you can use them in `Makefiles` and in `CMakeLists.txt.` If it's been downloaded from github actions