### PR TITLE
ci: install gettext for macOS port build

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -98,7 +98,7 @@ jobs:
       run: |
         curl -LO https://raw.githubusercontent.com/GiovanniBussi/macports-ci/master/macports-ci
         . ./macports-ci install --remove-brew --version=2.11.5 --sync=rsync
-        sudo port install gsl gmp mpfr libmpc libiconv bison flex gsed texinfo autoconf automake libtool md5sha1sum wget curl cmake
+        sudo port install gsl gmp mpfr libmpc libiconv bison flex gsed texinfo autoconf automake libtool md5sha1sum wget curl cmake gettext
 
     - name: Install MSYS2 packages
       if: startsWith(matrix.os.runs-on, 'windows')


### PR DESCRIPTION
## Summary
- The macOS ARM + MacPorts CI job currently fails when building `libconfuse`:
  ```
  configure.ac:31: error: undefined or overquoted macro: AM_GNU_GETTEXT
  configure.ac:32: error: undefined or overquoted macro: AM_GNU_GETTEXT_VERSION
  autoreconf: error: /opt/local/bin/autoconf failed with exit status: 1
  make: *** [libconfuse] Error 1
  ```
- MacPorts only pulled in `gettext-runtime` as a transitive dep (runtime libs only). The autoconf m4 macros (`AM_GNU_GETTEXT`, `AM_GNU_GETTEXT_VERSION`) live in the full `gettext` port.
- The brew job works because brew's `gettext` formula bundles the macros, which is why only the `port` matrix entry was failing.

## Test plan
- [x] `build (macos-latest, arm64, bash, , port)` reaches `libconfuse` and gets past `autoreconf`
- [x] No regression in the brew job (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)